### PR TITLE
Implemented HealthCheck Endpoint and improved Mailman resilience

### DIFF
--- a/adjutant_moc/actions/mailing_list.py
+++ b/adjutant_moc/actions/mailing_list.py
@@ -20,6 +20,51 @@ from adjutant_moc.actions import serializers
 from adjutant_moc.actions import base
 
 
+class Mailman(object):
+
+    def __init__(self, hostname, port, username, key):
+        self.hostname = hostname
+        self.port = port
+        self.username = username
+        self.key = key
+        self.client = paramiko.client.SSHClient()
+
+
+    def __enter__(self):
+        self.client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        self.client.connect(
+            hostname=self.hostname,
+            port=self.port,
+            username=self.username,
+            pkey=paramiko.RSAKey.from_private_key_file(self.key))
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.client.close()
+
+    def _execute(self, command):
+        stdin, stdout, stderr = self.client.exec_command(command)
+
+        errors = stderr.read()
+        if errors:
+            raise ConnectionError(errors)
+
+        # Note(knikolla): Not entirely sure if closing before reading is fine.
+        r = stdout.read().decode('utf-8').split('\n')
+        return r
+
+    def is_already_subscribed(self, email, list):
+        command = ('/usr/lib/mailman/bin/list_members %s' % list)
+        return email in self._execute(command)
+
+    def subscribe(self, email, list):
+        command = (
+                'echo %s | /usr/lib/mailman/bin/add_members -r - %s'
+                % (email, list)
+        )
+        self._execute(command)
+
+
 # TODO knikolla: there are going to be issues here when we
 # add invited users, since get email returns the one who created the task.
 class MailingListSubscribeAction(base.MocBaseAction):
@@ -105,13 +150,21 @@ class MailingListSubscribeAction(base.MocBaseAction):
         self._mailman(command)
 
     def _approve(self):
-        if self._is_already_subscribed():
-            self.add_note('Email %s already subscribed to mailing list.'
-                          % self._get_email())
-        else:
-            self._subscribe()
-            self.add_note('Email %s successfully subscribed to mailing list.'
-                          % self._get_email())
+        try:
+            with Mailman(self.config.host, self.config.port,
+                         self.config.user, self.config.private_key) as mailman:
+                if mailman.is_already_subscribed(self._get_email(),
+                                                 self.config.list):
+                    self.add_note('%s already subscribed to mailing list.'
+                                  % self._get_email())
+                else:
+                    mailman.subscribe(self._get_email(), self.config.list)
+                    self.add_note('%s successfully subscribed to mailing list.'
+                                  % self._get_email())
+        except paramiko.ssh_exception.SSHException as e:
+            self.add_note('Unable to connect to Mailing List server. '
+                          'Proceeding regardless. %s' % str(e))
+
         self.action.state = 'complete'
         self.action.save()
 

--- a/adjutant_moc/apis/__init__.py
+++ b/adjutant_moc/apis/__init__.py
@@ -10,6 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from adjutant_moc.apis import healthcheck  # noqa
 from adjutant_moc.apis import projects  # noqa
 from adjutant_moc.apis import roles  # noqa
 from adjutant_moc.apis import users  # noqa

--- a/adjutant_moc/apis/healthcheck.py
+++ b/adjutant_moc/apis/healthcheck.py
@@ -1,0 +1,61 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from confspirator import groups as config_groups
+from confspirator import fields as config_fields
+from rest_framework.response import Response
+from adjutant.api import utils
+
+from adjutant_moc.apis import base
+from adjutant_moc.actions import mailing_list
+
+from adjutant.config import CONF
+
+
+class MocHealthCheck(base.MocBaseApi):
+    """
+    API Endpoint for checking the health of Adjutant.
+    """
+    url = r'^moc/HealthCheck/?$'
+
+    config_group = config_groups.DynamicNameConfigGroup(
+        children=[
+            config_fields.BoolConfig(
+                'check_mailing_list',
+                help_text='Check SSH connection to mailing list server.',
+                default=True,
+                sample_default=True,
+            ),
+        ]
+    )
+
+    def get(self, request, format=None):
+        errors = {
+            'MailingList': self._check_mailing_list()
+        }
+
+        return Response({'errors': errors})
+
+    def _get_action_defaults(self, action):
+        return CONF.workflow.action_defaults.get(action)
+
+    def _check_mailing_list(self):
+        config = self._get_action_defaults('MailingListSubscribeAction')
+        try:
+            with mailing_list.Mailman(config.host,
+                                      config.port,
+                                      config.user,
+                                      config.private_key) as mailman:
+                mailman.is_already_subscribed('test@example.com', config.list)
+                return []
+        except Exception as e:
+            return [str(e)]

--- a/adjutant_moc/feature_set.py
+++ b/adjutant_moc/feature_set.py
@@ -30,6 +30,7 @@ class MocOnboardingFeatureSet(feature_set.BaseFeatureSet):
     ]
 
     delegate_apis = [
+        moc_apis.healthcheck.MocHealthCheck,
         moc_apis.projects.MocProjects,
         moc_apis.users.MocUsers,
         moc_apis.users.MocUsersDetail,

--- a/conf/adjutant.yaml
+++ b/conf/adjutant.yaml
@@ -41,6 +41,7 @@ identity:
 
 api:
   active_delegate_apis:
+    - MocHealthCheck
     - MocProjects
     - MocRoles
     - MocUsers

--- a/playbooks/files/adjutant.yaml
+++ b/playbooks/files/adjutant.yaml
@@ -44,6 +44,7 @@ identity:
 
 api:
   active_delegate_apis:
+    - MocHealthCheck
     - MocProjects
     - MocRoles
     - MocUsers


### PR DESCRIPTION
The /v1/moc/HealthCheck endpoint will perform checks for various
external components that the service needs access to. Ex. SSH
connection to the mailing list server, which is the primary
source of flakiness at the moment.

Additionally, refactored the Mailman code into a separate class, to
facilitate testing and health checking.

Finally, made failing to subscribe a user to a mailing list not
be a blocking error.