### PR TITLE
Fix wrong url in notification email

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://opendev.org/openstack/adjutant@eda6558b89608dc25a217cbb5625f63755989818#egg=python-adjutant
+git+https://github.com/CCI-MOC/adjutant@26b77fcb8f0d642971c0ac04b0563fcd9c49b595#egg=python-adjutant
 confspirator>=0.1.6<0.2
 paramiko>=2,<3
 pbr>=5,<6


### PR DESCRIPTION
Since this is in base adjutant, I've pushed the fix to a fork.
https://github.com/CCI-MOC/adjutant/commit/26b77fcb8f0d642971c0ac04b0563fcd9c49b595

Closes CCI-MOC/ops-issues#11